### PR TITLE
Fail negative test when no issues are found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run: pip install black
       - black/check:
           # little hack for negative test
-          path: "sample_files_unformatted || retCode=$?; if [[ $retCode -eq 1 ]]; then true; else false; fi"
+          path: 'sample_files_unformatted || f="y"; [ "$f" == "y" ]'
 
   integration-test-format-and-check:
     executor: python/default


### PR DESCRIPTION
The current implementation will ALWAYS pass the the `integration-test-check-unformatted` test, even when the command returns a success code.

This commit will change the command to return an error if no formatting errors are detected.

To test:

```sh
# should return 0
false || retCode=$?; if [[ $retCode -eq 1 ]]; then true; else false; fi
echo $?
# should return 1, but returns 0
true || retCode=$?; if [[ $retCode -eq 1 ]]; then true; else false; fi
echo $?
```
vs
```sh
# should return 0
unset f
false || f="y"; [ "$f" == "y" ]
echo $?
# should return 1
unset f
true || f="y"; [ "$f" == "y" ]
echo $?
```